### PR TITLE
Fixed non-portable flag error

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,2 +1,3 @@
-PKG_CPPFLAGS=@CXXFLAGS@ @CPPFLAGS@ -DNDEBUG -g
+#PKG_CPPFLAGS=@CXXFLAGS@ @CPPFLAGS@ -DNDEBUG -g  <This was generating warning as these flags are memorized by R and are used by default by Debian>
+PKG_CPPFLAGS=@CXXFLAGS@ @CPPFLAGS@ -DNDEBUG
 PKG_LIBS=@LDFLAGS@


### PR DESCRIPTION
Fixed this error:

checking compilation flags in Makevars ... WARNING
Non-portable flags in variable 'PKG_CPPFLAGS':
-g